### PR TITLE
Sort ProxyGroups according its index in GLOBAL group.

### DIFF
--- a/src/ducks/proxies.js
+++ b/src/ducks/proxies.js
@@ -16,10 +16,25 @@ const OptimisticSwitchProxy = 'proxies/OptimisticSwitchProxy';
 const CompletedRequestDelayForProxy = 'proxies/CompletedRequestDelayForProxy';
 
 function retrieveGroupNamesFrom(proxies) {
-  const groupNames = [];
+  var groupNames = [];
+  var globalAll = [];
   for (const prop in proxies) {
     const p = proxies[prop];
-    if (p.all && Array.isArray(p.all)) groupNames.push(prop);
+    if (p.all && Array.isArray(p.all)) {
+      groupNames.push(prop);
+      if (prop == 'GLOBAL') {
+        globalAll = p.all;
+      }
+    }
+  }
+  if (globalAll) {
+    // Put GLOBAL in the end
+    globalAll.push('GLOBAL');
+    // Sort groups according to its index in GLOBAL group
+    groupNames = groupNames
+      .map(name => [globalAll.indexOf(name), name])
+      .sort((a, b) => a[0] - b[0])
+      .map(group => group[1]);
   }
   return groupNames;
 }


### PR DESCRIPTION
Users are willing to see the ProxyGroups in the same order they write in the config file.

https://github.com/Dreamacro/clash/pull/284 can keep the original index of ProxyGroups in config file now.
