### PR TITLE
Detect clash API server at `/` when log in.

### DIFF
--- a/src/components/APIConfig.js
+++ b/src/components/APIConfig.js
@@ -21,8 +21,21 @@ function APIConfig2() {
   const actions = useActions({ updateClashAPIConfig });
 
   const contentEl = useRef(null);
+
+  const detectApiServer = async () => {
+    // if there is already a clash API server at `/`, just use it as default value
+    const res = await fetch('/');
+    res.json().then(data => {
+      if (data['hello'] === 'clash') {
+        setHostname(window.location.hostname);
+        setPort(window.location.port);
+      }
+    });
+  };
+
   useEffect(() => {
     contentEl.current.focus();
+    detectApiServer();
   }, []);
 
   const handleInputOnChange = e => {


### PR DESCRIPTION
In many circumstances, yacd is deployed along with clash API server.

When logging in, the user needs to copy and paste the URL in the browser to the log-in page.

![image](https://user-images.githubusercontent.com/1068203/66719170-bdaa6080-ee1e-11e9-86ee-ff6dd3e63ed0.png)

I think if yacd can confirm that there is a clash API server running at `/`, then we can use it as default value rather than `127.0.0.1:7892`. This is much more convenient.

This PR is just a **proof of concept**, and may violate the code style. Feel free to close it and rewrite it with your own style if possible.
