### PR TITLE
ci: support arm and arm64

### DIFF
--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -1,26 +1,8 @@
-# require the secrets DOCKER_HUB_PASSWORD
- 
-name: Release Docker Image
-on:
-  push:
-    tags:
-      - v*
+name: Build Docker Image
+on: [push, pull_request]
 jobs:
-  test:
+  build:
     runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - name: Run tests
-        run: |
-          if [ -f docker-compose.test.yml ]; then
-            docker-compose --file docker-compose.test.yml build
-            docker-compose --file docker-compose.test.yml run sut
-          else
-            docker build . --file Dockerfile
-          fi
-  push:
-    runs-on: ubuntu-latest
-    if: github.event_name == 'push'
     steps:
       - name: Set up Checkout
         uses: actions/checkout@v2
@@ -32,13 +14,7 @@ jobs:
           mv buildx ~/.docker/cli-plugins/docker-buildx
           docker run --rm --privileged multiarch/qemu-user-static:latest --reset -p yes --credential yes
           docker buildx create --use --name build --node build --driver-opt network=host
-      - name: Log in to Docker Hub
-        env:
-          DOCKER_USERNAME: ${{ github.actor }}
-          DOCKER_PASSWORD: ${{ secrets.DOCKER_HUB_PASSWORD }}
-        run: |
-          echo "${DOCKER_PASSWORD}" | docker login --username ${DOCKER_USERNAME} --password-stdin
-      - name: Build and push Docker image
+      - name: Build Docker image
         env:
           DOCKER_USERNAME: ${{ github.actor }}
           DOCKER_IMAGE_PLATFORM: linux/amd64,linux/arm/v7,linux/arm64
@@ -49,7 +25,7 @@ jobs:
           DOCKER_IMAGE_VERSION=${GITHUB_REF#refs/*/}
           docker buildx build \
             --platform "$DOCKER_IMAGE_PLATFORM" \
-            --output "type=image,push=true" \
+            --output "type=image,push=false" \
             --tag "$DOCKER_IMAGE_NAME":"$DOCKER_IMAGE_VERSION" \
             --tag "$DOCKER_IMAGE_NAME":latest \
             --file ./Dockerfile .

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -22,10 +22,8 @@ jobs:
         run: |
           IFS='/' read -ra repository_name_array <<<"$REPOSITORY_NAME"
           DOCKER_IMAGE_NAME=$(echo $DOCKER_USERNAME/${repository_name_array[1]} | tr '[:upper:]' '[:lower:]')
-          DOCKER_IMAGE_VERSION=${GITHUB_REF#refs/*/}
           docker buildx build \
             --platform "$DOCKER_IMAGE_PLATFORM" \
             --output "type=image,push=false" \
-            --tag "$DOCKER_IMAGE_NAME":"$DOCKER_IMAGE_VERSION" \
             --tag "$DOCKER_IMAGE_NAME":latest \
             --file ./Dockerfile .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,9 @@
 FROM node:alpine AS builder
 WORKDIR /app
 COPY . .
-RUN yarn && yarn run build
+# Using yarn to install dependencies in CI will cause network timeout
+# Refer to https://github.com/date-fns/date-fns/issues/1004
+RUN yarn config set network-timeout 300000 && yarn && yarn run build
 
 FROM nginx:alpine
 RUN rm -rf /usr/share/nginx/html/*


### PR DESCRIPTION
Resolved #519. This action will be triggered when the master branch commits a tag beginning with v. 

- The mirror of the arm platform will be used for Raspberry Pi and some servers.
- I did not provide linux/386 platform support because no one seems to use it,  it will increase the build time. If needed, just add `linux/386` in `DOCKER_IMAGE_PLATFORM`.

Please refer to the test results of the build image.

[GitHub Actions](https://github.com/kallydev/yacd/actions) / [Docker Hub](https://hub.docker.com/repository/docker/kallydev/yacd/tags)
