### PR TITLE
fix: requestDelayForProxy: encode URI for proxy name in case it contains special chars

### DIFF
--- a/src/api/proxies.ts
+++ b/src/api/proxies.ts
@@ -37,7 +37,7 @@ export async function requestDelayForProxy(
 ) {
   const { url, init } = getURLAndInit(apiConfig);
   const qs = `timeout=5000&url=${latencyTestUrl}`;
-  const fullURL = `${url}${endpoint}/${name}/delay?${qs}`;
+  const fullURL = `${url}${endpoint}/${encodeURIComponent(name)}/delay?${qs}`;
   return await fetch(fullURL, init);
 }
 


### PR DESCRIPTION
Special characters like "#" in proxy name breaks delay test because it's passed unencoded.

This PR fixes this.