### PR TITLE
Fix log level order

### DIFF
--- a/src/components/Config.tsx
+++ b/src/components/Config.tsx
@@ -29,8 +29,8 @@ const propsList = [{ id: 0 }, { id: 1 }, { id: 2 }, { id: 3 }];
 
 const logLeveOptions = [
   ['debug', 'Debug'],
-  ['warning', 'Warning'],
   ['info', 'Info'],
+  ['warning', 'Warning'],
   ['error', 'Error'],
   ['silent', 'Silent'],
 ];


### PR DESCRIPTION
The log levels should be ordered from the most verbose to the quietest.