### PR TITLE
Fix SideBar label wrap issue

### DIFF
--- a/src/components/SideBar.module.scss
+++ b/src/components/SideBar.module.scss
@@ -70,6 +70,7 @@
 .label {
   padding-left: 14px;
   font-size: 0.75em;
+  white-space: nowrap;
   @media (max-width: 768px) {
     padding-left: 0;
     padding-top: 5px;


### PR DESCRIPTION
![yacd haishan me_](https://user-images.githubusercontent.com/1709072/189834585-d148d3ed-2fb9-4563-a276-5981d5dd30e1.png)

当 proxies 展开的时候，sidebar label 被挤换行，要加个 `white-space: nowrap;`