### PR TITLE
fix: handle undefined when use old version clash.

### DIFF
--- a/src/components/Connections.tsx
+++ b/src/components/Connections.tsx
@@ -63,18 +63,18 @@ function filterConns(conns: FormattedConn[], keyword: string) {
   return !keyword
     ? conns
     : conns.filter((conn) =>
-      [
-        conn.host,
-        conn.sourceIP,
-        conn.sourcePort,
-        conn.destinationIP,
-        conn.chains,
-        conn.rule,
-        conn.type,
-        conn.network,
-        conn.processPath,
-      ].some((field) => hasSubstring(field, keyword))
-    );
+        [
+          conn.host,
+          conn.sourceIP,
+          conn.sourcePort,
+          conn.destinationIP,
+          conn.chains,
+          conn.rule,
+          conn.type,
+          conn.network,
+          conn.processPath,
+        ].some((field) => hasSubstring(field, keyword))
+      );
 }
 
 function formatConnectionDataItem(
@@ -83,7 +83,8 @@ function formatConnectionDataItem(
   now: number
 ): FormattedConn {
   const { id, metadata, upload, download, start, chains, rule, rulePayload } = i;
-  const { host, destinationPort, destinationIP, network, type, sourceIP, sourcePort, processPath } = metadata;
+  const { host, destinationPort, destinationIP, network, type, sourceIP, sourcePort, processPath } =
+    metadata;
   // host could be an empty string if it's direct IP connection
   let host2 = host;
   if (host2 === '') host2 = destinationIP;

--- a/src/components/Connections.tsx
+++ b/src/components/Connections.tsx
@@ -32,7 +32,7 @@ function arrayToIdKv<T extends { id: string }>(items: T[]) {
 }
 
 function basePath (path: string) {
-  return path ? path.replace(/.*[/\\]/, '') : path;
+  return path?.replace(/.*[/\\]/, '');
 }
 
 type FormattedConn = {

--- a/src/components/Connections.tsx
+++ b/src/components/Connections.tsx
@@ -32,7 +32,7 @@ function arrayToIdKv<T extends { id: string }>(items: T[]) {
 }
 
 function basePath (path: string) {
-  return path.replace(/.*[/\\]/, '')
+  return path ? path.replace(/.*[/\\]/, '') : path;
 }
 
 type FormattedConn = {

--- a/src/components/Connections.tsx
+++ b/src/components/Connections.tsx
@@ -31,7 +31,7 @@ function arrayToIdKv<T extends { id: string }>(items: T[]) {
   return o;
 }
 
-function basePath (path: string) {
+function basePath(path: string) {
   return path?.replace(/.*[/\\]/, '');
 }
 
@@ -63,18 +63,18 @@ function filterConns(conns: FormattedConn[], keyword: string) {
   return !keyword
     ? conns
     : conns.filter((conn) =>
-        [
-          conn.host,
-          conn.sourceIP,
-          conn.sourcePort,
-          conn.destinationIP,
-          conn.chains,
-          conn.rule,
-          conn.type,
-          conn.network,
-          conn.processPath,
-        ].some((field) => hasSubstring(field, keyword))
-      );
+      [
+        conn.host,
+        conn.sourceIP,
+        conn.sourcePort,
+        conn.destinationIP,
+        conn.chains,
+        conn.rule,
+        conn.type,
+        conn.network,
+        conn.processPath,
+      ].some((field) => hasSubstring(field, keyword))
+    );
 }
 
 function formatConnectionDataItem(


### PR DESCRIPTION
Compatible with old versions of the clash.

To solve problem:
```
Connections.07c28cc0.js:1 
        
Uncaught TypeError: Cannot read properties of undefined (reading 'replace')
    at di (Connections.07c28cc0.js:1:68259)
    at pi (Connections.07c28cc0.js:1:69001)
    at Connections.07c28cc0.js:1:69509
    at Array.map (<anonymous>)
    at Connections.07c28cc0.js:1:69501
    at index.5faed7a7.js:101:9304
    at Array.forEach (<anonymous>)
    at KD (index.5faed7a7.js:101:9293)
    at WebSocket.<anonymous> (index.5faed7a7.js:101:9473)
```
