### PR TITLE
优化代理延迟测速时的 UI 显示

### DIFF
--- a/src/components/proxies/ProxyLatency.tsx
+++ b/src/components/proxies/ProxyLatency.tsx
@@ -3,14 +3,14 @@ import * as React from 'react';
 import s0 from './ProxyLatency.module.scss';
 
 type ProxyLatencyProps = {
-  number?: number;
+  number?: any;
   color: string;
 };
 
 export function ProxyLatency({ number, color }: ProxyLatencyProps) {
   return (
     <span className={s0.proxyLatency} style={{ color }}>
-      {typeof number === 'number' && number !== 0 ? number + ' ms' : ' '}
+      {typeof number === 'number' ? (number !== 0 ? number + ' ms' : ' ') : number}
     </span>
   );
 }

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -41,7 +41,7 @@ export type ProxyItem = {
 };
 
 export type ProxyDelayItem = {
-  number?: number;
+  number?: any;
 };
 
 export type ProxiesMapping = Record<string, ProxyItem>;


### PR DESCRIPTION
作者您好, 一直在使用您的 yacd, 觉得很简洁好用, 不过遇到了一个小问题:
当点击节点测速时, 要等待所有的节点的测速完成才会一并更新结果, 且如果有个节点测速失败(比如超时), 它会保留上一次的延迟显示而不会更新.

当节点较多/存在无法连通的节点时这样给用户的体验感觉不太好, 要等满 5s 超时才能看到结果, 而不能直观地看出节点延迟的高低, 而且对于本次测速失败的节点仍然保留上一次的延迟可能会给用户带来误导.

所以我修改了一下相关代码, 把节点测速的行为改成了下面这样:

刚点击测速时显示如下图, 全部变为 `- ms`:
![image](https://user-images.githubusercontent.com/36782264/216339988-abd9d37b-af9e-4f98-ab7c-5b67694d07ba.png)

先测速完成的节点先显示结果, 测速出现错误的会显示错误原因:
![image](https://user-images.githubusercontent.com/36782264/216339526-7949073a-537d-4e3d-a0bf-8169e86cd048.png)

本次所有节点测速完成后会更新全部的 UI, 更新有依赖项目的延迟 (比如上面的例子中, Internet 的延迟应该是 direct 的延迟, 测速完成后会一并更新).

请作者 review 一下代码~ (不太熟悉 ts, 部分地方可能改得不好qvq 因为没怎么搞懂原来多代理测速这里的逻辑, 为什么用到 dedup, 什么情况下会发生重复吗, 只更新一次是为了性能考量吗?)