### PR TITLE
Fix infinite reload when context path isn't root in localhost

### DIFF
--- a/src/swRegistration.ts
+++ b/src/swRegistration.ts
@@ -23,7 +23,7 @@ export function register(config?: Config) {
     }
 
     window.addEventListener('load', () => {
-      const swUrl = `${process.env.PUBLIC_URL}/sw.js`;
+      const swUrl = `./sw.js`;
 
       if (isLocalhost) {
         // This is running on localhost. Let's check if a service worker still exists or not.


### PR DESCRIPTION
Fix #740, cause by [Fix PUBLIC_URL](https://github.com/haishanh/yacd/commit/a24a74e9e12aaa4fcff3e1e875e9e48bbe8ae245).