### PR TITLE
Make nginx to be process 1 to accept SIGTERM signal

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 sed -i "s|http://127.0.0.1:9090|$YACD_DEFAULT_BACKEND|" /usr/share/nginx/html/index.html
-nginx -g "daemon off;"
+exec nginx -g "daemon off;"


### PR DESCRIPTION
目前的脚本没有让 nginx 作为 1 号进程运行，nginx 无法收到 docker stop 发出的 SIGTERM 信号。关闭容器时，需要等待 10 秒左右，容器才能被强制关闭。修改后，容器可以在发出 docker stop 命令后立即退出。