### PR TITLE
reset selectedClashAPIConfigIndex when remove clashApiConfig

### DIFF
--- a/src/store/app.ts
+++ b/src/store/app.ts
@@ -55,6 +55,11 @@ export function removeClashAPIConfig(conf: ClashAPIConfig) {
     const idx = findClashAPIConfigIndex(getState, conf);
     dispatch('removeClashAPIConfig', (s) => {
       s.app.clashAPIConfigs.splice(idx, 1);
+      if (idx === s.app.selectedClashAPIConfigIndex) {
+        s.app.selectedClashAPIConfigIndex = 0;
+      } else if (idx < s.app.selectedClashAPIConfigIndex) {
+        s.app.selectedClashAPIConfigIndex -= 1;
+      }
     });
     // side effect
     saveState(getState().app);


### PR DESCRIPTION
修复问题: #735 
+ 问题出现的原因：在删除过程中，`clashAPIConfigs` 数组的长度变小，当被删除配置的索引小于 `selectedClashAPIConfigIndex` 时，可能出现 `selectedClashAPIConfigIndex`  大于等于数组长度的情况，此时数组越界

+ 解决方法：当删除当前正则被使用的配置前的配置时，对应地减小 `selectedClashAPIConfigIndex`