### PR TITLE
🐛 Fix the connections page crash

### DIFF
--- a/src/components/Connections.tsx
+++ b/src/components/Connections.tsx
@@ -57,7 +57,7 @@ type FormattedConn = {
 };
 
 function hasSubstring(s: string, pat: string) {
-  return s.toLowerCase().includes(pat.toLowerCase());
+  return (s ?? '').toLowerCase().includes(pat.toLowerCase());
 }
 
 function filterConns(conns: FormattedConn[], keyword: string) {


### PR DESCRIPTION
FormattedConn might contain `undefined` fields, causing the connection filter feature to crash sometimes in the `hasSubstring()` function.  This PR fixes it by returning `false `for string matches when the string is `null` or `undefined`.